### PR TITLE
Added Chrome and firefox support and secure key storage

### DIFF
--- a/background.js
+++ b/background.js
@@ -1,0 +1,36 @@
+if (typeof chrome !== "undefined" && chrome.runtime && chrome.runtime.getManifest) {
+    // Running in Chrome
+    console.log("Running in Chrome");
+    chrome.runtime.onInstalled.addListener((details) => {
+      switch (details.reason) {
+      case "install":
+        console.info("EXTENSION INSTALLED");
+        break;
+      case "update":
+        console.info("EXTENSION UPDATED");
+        break;
+      default:
+        console.info("BROWSER UPDATED");
+        break;
+      }
+    });
+} else if (typeof browser !== "undefined" && browser.runtime && browser.runtime.getManifest) {
+    // Running in Firefox
+    console.log("Running in Firefox");
+    browser.runtime.onInstalled.addListener((details) => {
+      switch (details.reason) {
+      case "install":
+        console.info("EXTENSION INSTALLED");
+        break;
+      case "update":
+        console.info("EXTENSION UPDATED");
+        break;
+      default:
+        console.info("BROWSER UPDATED");
+        break;
+  }
+});
+} else {
+    // Not running in a supported browser
+    console.error("Unsupported browser");
+}

--- a/config.json
+++ b/config.json
@@ -1,0 +1,3 @@
+{
+  "SECRET": "MySecretKey",
+}

--- a/manifest.json
+++ b/manifest.json
@@ -10,6 +10,15 @@
     "browser_action": {
         "default_title": "TOTP",
         "default_popup": "popup.html"
+    },
+    
+    "web_accessible_resources": [
+        "config.json"
+    ],
+    
+    "background": {
+        "scripts": ["background.js"],
+        "persistent": false
     }
 }
   

--- a/totp.js
+++ b/totp.js
@@ -27,7 +27,21 @@ async function base32Decode(encoded) {
 
     return new Uint8Array(bytes);
 }
-
+async function loadConfig() {
+    try {
+        if(typeof chrome !== "undefined" && chrome.runtime && chrome.runtime.getManifest){
+            const response = await fetch(chrome.runtime.getURL('config.json'));
+        }
+        else if(typeof browser !== "undefined" && browser.runtime && browser.runtime.getManifest){
+            const response = await fetch(browser.runtime.getURL('config.json'));
+        }
+        const data = await response.json();
+        return data.SECRET;
+    } catch (error) {
+        console.error('Error loading config:', error);
+        return null;
+    }
+}
 async function generateTOTP(secret) {
     
     const key = secret; // Placeholder, replace with actual byte array conversion


### PR DESCRIPTION
I have added a way to use the extension in both chrome and firefox in order to use the secure key storage. I have put the key in a config.json file. Where the browser runtime will receive the key and gives the 2fa key. Plus i made sure to make the extension work even after the browser closes by creating a simple background script.